### PR TITLE
track another lz4 repo

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -298,7 +298,7 @@
   <project path="external/lohit-fonts" name="platform/external/lohit-fonts" remote="aosp" />
   <project path="external/ltrace" name="platform/external/ltrace" groups="pdk-cw-fs" remote="aosp" />
   <project path="external/lsof" name="CyanogenMod/android_external_lsof" />
-  <project path="external/lz4" name="CyanogenMod/android_external_lz4" />
+  <project path="external/lz4" name="Khaon/android_external_lz4" />
   <project path="external/lzma" name="CyanogenMod/android_external_lzma" />
   <project path="external/lzo" name="CyanogenMod/android_external_lzo" />
   <project path="external/markdown" name="platform/external/markdown" groups="pdk-cw-fs" remote="aosp" />


### PR DESCRIPTION
Change-Id: Id760e2f600b92705398ce1238a25930107e21824

My repo is up to date with lz4 upstream sources(r131) and I have defined those modules in the makefiles:
https://github.com/Khaon/android_external_lz4/commit/6689a8fa58c8a94a90198ebe68b159e08904086f

So what differs from Cyanogenmod is more adjusted flags 
https://github.com/Khaon/android_external_lz4/commit/6689a8fa58c8a94a90198ebe68b159e08904086f#diff-4b9d23769777603f9216c10b589245a4R6

to match the real makefiles

https://github.com/Khaon/android_external_lz4/blob/cm-12.1/programs/Makefile#L42

Also it builds both for the host and the target the lz4 binary instead of just the host.
https://github.com/Khaon/android_external_lz4/blob/cm-12.1/programs/Makefile#L42

We are building gzip for both and host and target device, therefore I think it should be the same for lz4 binary.

Don't merge this if you agree with that, just fork :p
