### PR TITLE
track own f2fs tools

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -78,6 +78,7 @@
   <project path="external/sepolicy" name="temasek/android_external_sepolicy" remote="github" revision="cm-12.1" />
   <project path="external/sqlite" name="arter97/android_external_sqlite" remote="github" revision="cm-12.1" />
   <project path="external/wpa_supplicant_8" name="temasek/android_external_wpa_supplicant_8" remote="github" revision="cm-12.1" />
+  <project path="external/f2fs-tools" name="temasek/android_external_f2fs-tools" remote="github" revision="cm-12.1" />
   <!-- END of temasek -->
 
   <project path="abi/cpp" name="CyanogenMod/android_abi_cpp" groups="pdk" />
@@ -197,7 +198,7 @@
   <project path="external/exfat" name="CyanogenMod/android_external_exfat" />
   <project path="external/expat" name="platform/external/expat" groups="pdk" remote="aosp" />
   <project path="external/eyes-free" name="platform/external/eyes-free" groups="pdk-cw-fw" remote="aosp" />
-  <project path="external/f2fs-tools" name="CyanogenMod/android_external_f2fs-tools" groups="pdk" />
+  <!--<project path="external/f2fs-tools" name="CyanogenMod/android_external_f2fs-tools" groups="pdk" /> -->
   <project path="external/fdlibm" name="platform/external/fdlibm" groups="pdk" remote="aosp" />
   <project path="external/ffmpeg" name="CyanogenMod/android_external_ffmpeg" />
   <project path="external/fio" name="platform/external/fio" remote="aosp" />


### PR DESCRIPTION
I have updated cyanogen's f2fs tools project to be in line with jaegeuk master's branch.

https://kernel.googlesource.com/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools/+log/master

I had this idea while reviewing moto's repos : 

https://github.com/MotorolaMobilityLLC/motorola-external-f2fs-tools/commits/lollipop-5.0.2-release-shamu_cn

Building and  fscking -a from the twrp recovery is working.

repository to fork : https://github.com/Khaon/android_external_f2fs-tools
